### PR TITLE
fix: incorrect qrcode rendering when `invert` is enabled

### DIFF
--- a/logic/generate.ts
+++ b/logic/generate.ts
@@ -653,10 +653,10 @@ export async function generateQRCode(canvas: HTMLCanvasElement, state: QRCodeGen
       }
       else {
         if (_pixelStyle === 'rounded') {
-          corner(0, (top && left && topLeft) ? darkColor : lightColor)
-          corner(2, (top && right && topRight) ? darkColor : lightColor)
-          corner(1, (bottom && left && bottomLeft) ? darkColor : lightColor)
-          corner(3, (bottom && right && bottomRight) ? darkColor : lightColor)
+          corner(0, (top && left && topLeft && !isBorder) ? darkColor : lightColor)
+          corner(2, (top && right && topRight && !isBorder) ? darkColor : lightColor)
+          corner(1, (bottom && left && bottomLeft && !isBorder) ? darkColor : lightColor)
+          corner(3, (bottom && right && bottomRight && !isBorder) ? darkColor : lightColor)
         }
       }
       dot()


### PR DESCRIPTION
### Before:

![M_x20  (1)](https://github.com/Dunqing/qrcode-toolkit/assets/29533304/5b58cfe3-927e-4341-b9aa-4d5ac8e314a3)

### After:

![image](https://github.com/Dunqing/qrcode-toolkit/assets/29533304/affbceea-b0f4-4d8f-aca7-755e39eba2c8)