### PR TITLE
fix: input value in ImageUpload.vue & background img resize in generate.ts

### DIFF
--- a/components/ImageUpload.vue
+++ b/components/ImageUpload.vue
@@ -7,7 +7,10 @@ const emit = defineEmits<{
   (event: 'update:modelValue', dataurl: string): void
 }>()
 
+const value = ref<any>()
+
 async function read(e: Event) {
+  value.value = ''
   const file = (e.target as HTMLInputElement).files?.[0]
   if (!file)
     return
@@ -27,6 +30,7 @@ async function read(e: Event) {
 <template>
   <input
     type="file" accept="image/*"
+    :value="value"
     absolute bottom-0 left-0 right-0 top-0 z-10
     max-h-full max-w-full cursor-pointer opacity-0.1
     @input="read"

--- a/logic/generate.ts
+++ b/logic/generate.ts
@@ -860,11 +860,11 @@ export async function generateQRCode(outCanvas: HTMLCanvasElement, state: QRCode
         await new Promise(resolve => img.onload = resolve).then()
         // draw the image full cover the canvas with aspect ratio
         const imgRatio = img.width / img.height
-        const canvasRatio = outCanvas.width / outCanvas.height
+        const canvasRatio = width / height
         if (imgRatio < canvasRatio)
-          ctx.drawImage(img, 0, (outCanvas.height - outCanvas.width / imgRatio) / 2, outCanvas.width, outCanvas.width / imgRatio)
+          ctx.drawImage(img, 0, (height - width / imgRatio) / 2, width, width / imgRatio)
         else
-          ctx.drawImage(img, (outCanvas.width - outCanvas.height * imgRatio) / 2, 0, outCanvas.height * imgRatio, outCanvas.height)
+          ctx.drawImage(img, (width - height * imgRatio) / 2, 0, height * imgRatio, height)
       }
     }
 


### PR DESCRIPTION
### Description
1. When uploading image in some pages (such as `Verify` page), the browser's default behavior is to prevent selecting and uploading the same file multiple times (as shown in video recording below). But I think this limitation could be bypassed.

https://github.com/antfu/qrcode-toolkit/assets/4465685/881b0961-e4ac-433b-8a25-ce64d7da3b87


2. In `Generator` page, when a background image is set, it cannot accurately change its size when setting the `margin` option (as shown in video recording below).


https://github.com/antfu/qrcode-toolkit/assets/4465685/34c42a73-7d3b-4957-abc8-25c01ac1a7eb


### Linked Issues
None.

### Additional context
None.
